### PR TITLE
Port rule compiler to Node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+/dist
+/tmp
+/out-tsc
+
+# dependencies
+/node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+*.sublime-workspace
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage
+/libpeerconnection.log
+npm-debug.log
+yarn-error.log
+testem.log
+/typings
+
+# System Files
+.DS_Store
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:8.11
+WORKDIR /src
+ADD package.json .
+RUN npm install --quiet
+ADD . .
+CMD npm test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+BUILD=./build.js
+
+all:
+	@$(BUILD) *.txt

--- a/build.js
+++ b/build.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+var cmd = require('commander');
+var rulebook = require('./rulebook.js');
+
+cmd
+  .arguments('<rulesets...>')
+  .action((rulesets) => {
+    console.log(JSON.stringify(rulebook.buildRulesets(rulesets)));
+  });
+
+cmd.parse(process.argv);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "aksornklang",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "aksornklang",
+  "version": "1.0.0",
+  "description": "This is the official reference that is applied by the Aksorn engine. Like a secret sauce minus the secrecy.",
+  "main": "rulebook.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scomma/aksornklang.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/scomma/aksornklang/issues"
+  },
+  "homepage": "https://github.com/scomma/aksornklang#readme",
+  "dependencies": {
+    "commander": "^2.19.0"
+  }
+}

--- a/rulebook.js
+++ b/rulebook.js
@@ -1,0 +1,23 @@
+var fs = require('fs');
+
+exports.buildRulesets = (filenames) => {
+  return filenames.map(exports.buildRuleset);
+}
+
+exports.buildRuleset = (filename) => {
+  var blob  = fs.readFileSync(filename, 'utf8');
+  var rules = blob.split("\n\n").map(exports.buildRule);
+  return {
+    name:  filename,
+    rules: rules
+  }
+}
+
+exports.buildRule = (blob) => {
+  var lines = blob.split("\n");
+  var rule  = { match: lines };
+  if (lines.length > 1) {
+    rule.suggest = lines.pop();
+  }
+  return rule;
+}


### PR DESCRIPTION
Part of #16.

The compiler turns rules files into JSON structures for consumption by the engine.
Part of its code can be used to create the test suite.

Running make will compile all rules and dump the output to stdout.